### PR TITLE
Add handle to product query

### DIFF
--- a/src/product-query.js
+++ b/src/product-query.js
@@ -12,6 +12,7 @@ module.exports = `query ProductsQuery {
             title
             createdAt
             updatedAt
+            handle
             variants(first: 250) {
               pageInfo {
                 hasNextPage


### PR DESCRIPTION
Thx for a great plugin. Used this plugin for a project and felt that the handle was missing from the product query. Made my own copy, but figure it's nicer to update the original :)